### PR TITLE
fix: correctly handle nullable types

### DIFF
--- a/src/jsf/schema_types/enum.py
+++ b/src/jsf/schema_types/enum.py
@@ -10,7 +10,7 @@ _types = {"string": str, "integer": int, "number": float}
 
 
 class JSFEnum(BaseSchema):
-    enum: Optional[List[Union[str, int, float]]] = []
+    enum: Optional[List[Union[str, int, float, None]]] = []
 
     def generate(self, context: Dict[str, Any]) -> Optional[Union[str, int, float]]:
         try:

--- a/src/jsf/schema_types/number.py
+++ b/src/jsf/schema_types/number.py
@@ -45,7 +45,8 @@ class Number(BaseSchema):
 
 class Integer(Number):
     def generate(self, context: Dict[str, Any]) -> Optional[int]:
-        return int(super().generate(context))
+        n = super().generate(context)
+        return int(n) if n else n
 
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, int)

--- a/src/jsf/schema_types/string.py
+++ b/src/jsf/schema_types/string.py
@@ -68,7 +68,8 @@ class String(BaseSchema):
 
     def generate(self, context: Dict[str, Any]) -> Optional[str]:
         try:
-            return str(super().generate(context))
+            s = super().generate(context)
+            return str(s) if s else s
         except ProviderNotSetException:
             format_map["regex"] = lambda: rstr.xeger(self.pattern)
             format_map["relative-json-pointer"] = lambda: random.choice(context["state"]["__all_json_paths__"])

--- a/src/tests/data/type-list-null.json
+++ b/src/tests/data/type-list-null.json
@@ -1,0 +1,46 @@
+{
+  "str": {
+    "type": ["string", "null"]
+  },
+  "int": {
+    "type": ["integer", "null"]
+  },
+  "num": {
+    "type": ["number", "null"]
+  },
+  "bool": {
+    "type": ["boolean", "null"]
+  },
+  "enum": {
+    "enum": ["r", "g", "b", null]
+  },
+  "arr": {
+    "type": ["array", "null"],
+    "items": {"type": "integer"}
+  },
+  "arr_nested": {
+    "type": "array",
+    "items": {"type": ["integer", "null"]}
+  },
+  "obj": {
+    "type": ["object", "null"],
+    "required": ["req"],
+    "properties": {
+      "req": {
+        "type": "boolean"
+      },
+      "non_req": {
+        "type": "integer"
+      }
+    }
+  },
+  "obj_nested": {
+    "type": "object",
+    "required": ["req"],
+    "properties": {
+      "req": {
+        "type": ["boolean", "null"]
+      }
+    }
+  }
+}

--- a/src/tests/test_nullable_types_gen.py
+++ b/src/tests/test_nullable_types_gen.py
@@ -1,0 +1,88 @@
+import json
+
+from ..jsf.parser import JSF
+
+
+def test_string_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["str"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(each not in ["None"] for each in actual)
+    assert all(type(each) in [type(None), str] for each in actual)
+
+
+def test_int_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["int"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each) in [type(None), int] for each in actual)
+
+
+def test_number_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["num"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each) in [type(None), float] for each in actual)
+
+
+def test_boolean_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["bool"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each) in [type(None), bool] for each in actual)
+
+
+def test_enum_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["enum"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(each in ["r", "g", "b", None] for each in actual)
+
+
+def test_array_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["arr"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each) in [list, type(None)] for each in actual)
+
+
+def test_array_nested_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["arr_nested"])
+
+    actual = [p.generate() for _ in range(100)]
+    items = [item for each in actual for item in each]
+
+    assert all(type(each) in [int, type(None)] for each in items)
+
+
+def test_object_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["obj"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each) in [dict, type(None)] for each in actual)
+
+
+def test_object_nested_null_gen(TestData):
+    with open(TestData / f"type-list-null.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema["obj_nested"])
+
+    actual = [p.generate() for _ in range(100)]
+    assert all(type(each["req"]) in [bool, type(None)] for each in actual)
+


### PR DESCRIPTION
# Description

Several data types were handling null values incorrectly. In particular, enums and integers would simply error when presented with a type list containing "null", and strings would produce the string "None". This PR fixes that to correctly produce None values in these cases, and adds tests to cover schemas which include "null" in the type list.