### PR TITLE
support for string duration format

### DIFF
--- a/examples/fastapi/api.py
+++ b/examples/fastapi/api.py
@@ -1,5 +1,6 @@
-from jsf import JSF
 from fastapi import FastAPI
+
+from jsf import JSF
 
 app = FastAPI(docs_url="/")
 generator = JSF.from_json("custom.json")

--- a/examples/fastapi/model.py
+++ b/examples/fastapi/model.py
@@ -11,62 +11,34 @@ from pydantic import BaseModel, Field
 
 class NewbornItem(BaseModel):
     surname: str = Field(..., description="The newborn's surname, eg: Reid")
-    givenNames: str = Field(
-        ..., description="The newborn's given names, eg: Mathew David"
-    )
+    givenNames: str = Field(..., description="The newborn's given names, eg: Mathew David")
     sex: str = Field(..., description="The newborn's sex, eg: M, F or U")
-    dateOfBirth: str = Field(
-        ..., description="The newborn's date of birth, eg: 17/03/2021"
-    )
+    dateOfBirth: str = Field(..., description="The newborn's date of birth, eg: 17/03/2021")
     birthOrder: str = Field(..., description="The newborn's birth order, eg: 1")
-    indigenousStatus: str = Field(
-        ..., description="The newborn's indigenous status, eg: 14"
-    )
-    uniqueId: str = Field(
-        ..., description="The newborn's unique birth event id, eg: 20474417"
-    )
+    indigenousStatus: str = Field(..., description="The newborn's indigenous status, eg: 14")
+    uniqueId: str = Field(..., description="The newborn's unique birth event id, eg: 20474417")
 
 
 class Address(BaseModel):
-    suburb: str = Field(
-        ..., description='The address suburb (Australia Only), eg: Watson'
-    )
-    postcode: str = Field(
-        ..., description='The address postcode (Australia Only), eg: 2602'
-    )
+    suburb: str = Field(..., description="The address suburb (Australia Only), eg: Watson")
+    postcode: str = Field(..., description="The address postcode (Australia Only), eg: 2602")
     street1: str = Field(
         ...,
-        description='The address street name line 1 (Australia Only), eg: 49 Aspinall St',
+        description="The address street name line 1 (Australia Only), eg: 49 Aspinall St",
     )
-    street2: str = Field(
-        ..., description='The address street name line 2 (Australia Only), eg: Suite 1'
-    )
+    street2: str = Field(..., description="The address street name line 2 (Australia Only), eg: Suite 1")
 
 
 class Parent(BaseModel):
-    surname: Optional[str] = Field(
-        ..., description="The mother's surname, eg: Mcdermott"
-    )
-    givenNames: str = Field(
-        ..., description="The mother's given names, eg: Sarah Lousie"
-    )
+    surname: Optional[str] = Field(..., description="The mother's surname, eg: Mcdermott")
+    givenNames: str = Field(..., description="The mother's given names, eg: Sarah Lousie")
     mailAddress: Address
     residentialAddress: Address
-    mobile: str = Field(
-        ..., description="The mother's mobile phone number, eg: 0400182545"
-    )
-    homePhone: str = Field(
-        ..., description="The mother's home phone number, eg: 0245458450"
-    )
-    email: str = Field(
-        ..., description="The mother's email address, eg: jesse6565656565@gmail.com"
-    )
-    hospital: str = Field(
-        ..., description='The hospital where the birth took place, eg: ACTCC'
-    )
-    dateReceived: str = Field(
-        ..., description='The date the birth event was received, eg: 17/03/2021'
-    )
+    mobile: str = Field(..., description="The mother's mobile phone number, eg: 0400182545")
+    homePhone: str = Field(..., description="The mother's home phone number, eg: 0245458450")
+    email: str = Field(..., description="The mother's email address, eg: jesse6565656565@gmail.com")
+    hospital: str = Field(..., description="The hospital where the birth took place, eg: ACTCC")
+    dateReceived: str = Field(..., description="The date the birth event was received, eg: 17/03/2021")
     personId: str = Field(..., description="The mother's personId, eg: 123456789")
 
 

--- a/src/jsf/cli.py
+++ b/src/jsf/cli.py
@@ -10,10 +10,22 @@ app = typer.Typer()
 @app.command()
 def main(
     schema: Path = typer.Option(
-        ..., exists=True, file_okay=True, dir_okay=False, writable=False, readable=True, resolve_path=True,
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
     ),
     instance: Path = typer.Option(
-        ..., exists=False, file_okay=True, dir_okay=False, writable=True, readable=False, resolve_path=True,
+        ...,
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        readable=False,
+        resolve_path=True,
     ),
 ):
     JSF.from_json(schema).to_json(instance)

--- a/src/jsf/parser.py
+++ b/src/jsf/parser.py
@@ -11,7 +11,7 @@ from jsonschema import validate
 from pydantic import conlist
 from smart_open import open as s_open
 
-from .schema_types import AllTypes, Array, JSFEnum, JSFTuple, Object, PrimativeTypes, Primitives, AnyOf
+from .schema_types import AllTypes, AnyOf, Array, JSFEnum, JSFTuple, Object, PrimativeTypes, Primitives
 
 logger = logging.getLogger()
 faker = Faker()

--- a/src/jsf/schema_types/__init__.py
+++ b/src/jsf/schema_types/__init__.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from ._tuple import JSFTuple
+from .anyof import AnyOf
 from .array import Array
 from .boolean import Boolean
 from .enum import JSFEnum
@@ -8,7 +9,6 @@ from .null import Null
 from .number import Integer, Number
 from .object import Object
 from .string import String
-from .anyof import AnyOf
 
 Primitives = {
     "number": Number,

--- a/src/jsf/schema_types/anyof.py
+++ b/src/jsf/schema_types/anyof.py
@@ -20,4 +20,3 @@ class AnyOf(BaseSchema):
 
     def model(self, context: Dict[str, Any]):
         pass
-

--- a/src/jsf/schema_types/object.py
+++ b/src/jsf/schema_types/object.py
@@ -2,7 +2,7 @@ import logging
 import random
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import create_model, BaseModel
+from pydantic import BaseModel, create_model
 
 from .base import BaseSchema, ProviderNotSetException
 

--- a/src/jsf/schema_types/string.py
+++ b/src/jsf/schema_types/string.py
@@ -15,6 +15,7 @@ faker = Faker()
 FRAGMENT = "[a-zA-Z][a-zA-Z0-9+-.]*"
 URI_PATTERN = f"https?://{{hostname}}(?:{FRAGMENT})+"
 PARAM_PATTERN = "(?:\\?([a-z]{1,7}(=\\w{1,5})?&){0,3})?"
+DURATION_PATTERN = "[0-9]{10}"
 
 LOREM = """Lorem ipsum dolor sit amet consectetur adipisicing elit.
 Hic molestias, esse veniam placeat officiis nobis architecto modi
@@ -25,6 +26,7 @@ format_map: Dict[str, Callable] = {
     "date-time": lambda: faker.date_time(timezone.utc).isoformat(),
     "time": lambda: faker.date_time(timezone.utc).isoformat().split("T")[1],
     "date": lambda: faker.date_time(timezone.utc).isoformat().split("T")[0],
+    "duration": lambda: rstr.xeger(DURATION_PATTERN),
     "email": faker.email,
     "idn-email": faker.email,
     "hostname": faker.hostname,

--- a/src/tests/data/string-format.json
+++ b/src/tests/data/string-format.json
@@ -4,6 +4,7 @@
         "date-time",
         "time",
         "date",
+        "duration",
         "email",
         "idn-email",
         "hostname",
@@ -32,6 +33,10 @@
         "date": {
             "type": "string",
             "format": "date"
+        },
+        "duration": {
+            "type": "string",
+            "format": "duration"
         },
         "email": {
             "type": "string",

--- a/src/tests/test_default_fake.py
+++ b/src/tests/test_default_fake.py
@@ -200,6 +200,7 @@ def test_fake_string_format(TestData):
         bool(re.match(r"\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\+\d{2}\:\d{2}", d["date-time"])) for d in fake_data
     ), fake_data
     assert all(bool(re.match(r"\d{4}-\d{2}-\d{2}", d["date"])) for d in fake_data), fake_data
+    assert all(bool(re.match(r"[0-9]{10}", d["duration"])) for d in fake_data), fake_data
     assert all(bool(re.match(r"\d{2}\:\d{2}\:\d{2}\+\d{2}\:\d{2}", d["time"])) for d in fake_data), fake_data
     assert all(bool(re.match(r"[a-zA-Z0-9+-\.]{1,33}\.[a-z]{2,4}", d["hostname"])) for d in fake_data)
     assert all(bool(re.match(r"[a-zA-Z0-9+-\.]{1,33}\.[a-z]{2,4}", d["idn-hostname"])) for d in fake_data)

--- a/src/tests/test_model_gen.py
+++ b/src/tests/test_model_gen.py
@@ -38,7 +38,8 @@ else:
 
 
 @pytest.mark.parametrize(
-    "filestem, expected_type_anno", expected,
+    "filestem, expected_type_anno",
+    expected,
 )
 def test_gen_model(TestData, filestem, expected_type_anno):
     with open(TestData / f"{filestem}.json", "r") as file:

--- a/src/tests/test_nullable_types_gen.py
+++ b/src/tests/test_nullable_types_gen.py
@@ -85,4 +85,3 @@ def test_object_nested_null_gen(TestData):
 
     actual = [p.generate() for _ in range(100)]
     assert all(type(each["req"]) in [bool, type(None)] for each in actual)
-

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -4,7 +4,8 @@ from ..jsf.schema_types.string import random_fixed_length_sentence
 
 
 @pytest.mark.parametrize(
-    "_min, _max", [(0, 1), (0, 0), (0, 10), (10, 20), (10, 2000)],
+    "_min, _max",
+    [(0, 1), (0, 0), (0, 10), (10, 20), (10, 2000)],
 )
 def test_random_fixed_length_sentence(_min, _max):
     gen = random_fixed_length_sentence(_min, _max)


### PR DESCRIPTION
simply generate fixed length string {10} that contains 0-9 digits 
https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times