### PR TITLE
feat: [parser]: Support $defs keyword for in-schema definitions

### DIFF
--- a/src/jsf/parser.py
+++ b/src/jsf/parser.py
@@ -122,9 +122,10 @@ class JSF:
             raise ValueError(f"Cannot parse schema {repr(schema)}")  # pragma: no cover
 
     def _parse(self, schema: Dict[str, Any]) -> AllTypes:
-        for name, definition in schema.get("definitions", {}).items():
-            item = self.__parse_definition(name, path="#/definitions", schema=definition)
-            self.definitions[f"#/definitions/{name}"] = item
+        for def_tag in ("definitions", "$defs"):
+            for name, definition in schema.get(def_tag, {}).items():
+                item = self.__parse_definition(name, path=f"#/{def_tag}", schema=definition)
+                self.definitions[f"#/{def_tag}/{name}"] = item
 
         self.root = self.__parse_definition(name="root", path="#", schema=schema)
 

--- a/src/tests/data/inner-ref.json
+++ b/src/tests/data/inner-ref.json
@@ -7,6 +7,9 @@
                 "id": {
                     "$ref": "#/definitions/positiveInt"
                 },
+                "uuid": {
+                    "$ref": "#/$defs/uuid"
+                },
                 "name": {
                     "type": "string",
                     "faker": "name.findName"
@@ -25,7 +28,7 @@
                     "faker": "internet.email"
                 }
             },
-            "required": ["id", "name", "birthday", "email"]
+            "required": ["id", "uuid", "name", "birthday", "email"]
         }
     },
     "required": ["user"],
@@ -34,6 +37,12 @@
             "type": "integer",
             "minimum": 0,
             "minimumExclusive": true
+        }
+    },
+    "$defs": {
+        "uuid": {
+            "type": "string",
+            "pattern": "^[0-9A-F]{16,}$"
         }
     }
 }

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -71,5 +71,5 @@ def test_nested_object_ref(TestData):
     assert hasattr(p.root, "properties")
     expected_types = {"user": Object}
     assert {prop.name: type(prop) for prop in p.root.properties} == expected_types
-    expected_types = {"birthday": String, "email": String, "name": String, "id": Integer}
+    expected_types = {"birthday": String, "email": String, "name": String, "id": Integer, "uuid": String}
     assert {prop.name: type(prop) for prop in p.root.properties[0].properties} == expected_types


### PR DESCRIPTION
Fixes #35 -  Make "definitions" variable in JSF._parse method