### PR TITLE
feat: [parser]: Support 'oneOf' keyword

### DIFF
--- a/src/jsf/parser.py
+++ b/src/jsf/parser.py
@@ -11,7 +11,7 @@ from jsonschema import validate
 from pydantic import conlist
 from smart_open import open as s_open
 
-from .schema_types import AllTypes, Array, JSFEnum, JSFTuple, Object, PrimativeTypes, Primitives, AnyOf
+from .schema_types import AllTypes, Array, JSFEnum, JSFTuple, Object, PrimativeTypes, Primitives, AnyOf, OneOf
 
 logger = logging.getLogger()
 faker = Faker()
@@ -117,7 +117,12 @@ class JSF:
             schemas = []
             for d in schema["anyOf"]:
                 schemas.append(self.__parse_definition(name, path, d))
-            return AnyOf(schemas=schemas)
+            return AnyOf(name=name, path=path, schemas=schemas)
+        elif "oneOf" in schema:
+            schemas = []
+            for d in schema["oneOf"]:
+                schemas.append(self.__parse_definition(name, path, d))
+            return OneOf(name=name, path=path, schemas=schemas)
         else:
             raise ValueError(f"Cannot parse schema {repr(schema)}")  # pragma: no cover
 

--- a/src/jsf/schema_types/__init__.py
+++ b/src/jsf/schema_types/__init__.py
@@ -9,6 +9,7 @@ from .number import Integer, Number
 from .object import Object
 from .string import String
 from .anyof import AnyOf
+from .oneof import OneOf
 
 Primitives = {
     "number": Number,
@@ -19,5 +20,5 @@ Primitives = {
     "null": Null,
 }
 
-AllTypes = Union[JSFEnum, Object, Array, JSFTuple, String, Boolean, Null, Number, Integer, AnyOf]
+AllTypes = Union[JSFEnum, Object, Array, JSFTuple, String, Boolean, Null, Number, Integer, AnyOf, OneOf]
 PrimativeTypes = Union[String, Boolean, Null, Number, Integer]

--- a/src/jsf/schema_types/oneof.py
+++ b/src/jsf/schema_types/oneof.py
@@ -1,0 +1,20 @@
+import random
+from typing import Any, Dict, List, Optional
+
+from .base import BaseSchema, ProviderNotSetException
+
+
+class OneOf(BaseSchema):
+    schemas: List[BaseSchema] = None
+
+    def from_dict(d):
+        return OneOf(**d)
+
+    def generate(self, context: Dict[str, Any]) -> Optional[List[Any]]:
+        try:
+            return super().generate(context)
+        except ProviderNotSetException:
+            return random.choice(self.schemas).generate(context)
+
+    def model(self, context: Dict[str, Any]):
+        pass

--- a/src/tests/data/oneof.json
+++ b/src/tests/data/oneof.json
@@ -1,0 +1,11 @@
+{
+  "oneOf": [
+    {
+      "type": "string",
+      "maxLength": 5
+    },
+    {
+      "type": "boolean"
+    }
+  ]
+}

--- a/src/tests/test_default_fake.py
+++ b/src/tests/test_default_fake.py
@@ -13,6 +13,14 @@ def test_fake_anyof(TestData):
     for d in fake_data:
         assert isinstance(d, str) or isinstance(d, float)
 
+def test_fake_oneof(TestData):
+    with open(TestData / f"oneof.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+
+    fake_data = [p.generate() for _ in range(10)]
+    for d in fake_data:
+        assert isinstance(d, bool) or isinstance(d, str)
 
 def test_fake_boolean(TestData):
     with open(TestData / f"boolean.json", "r") as file:


### PR DESCRIPTION
Also, set the "name" and "path" properties for 'OneOf' and 'AnyOf' instances. These schema composition types can be associated with a specific property.