### PR TITLE
force reading README.md in utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
This updates the `setup.py` to be more robust vs. non-utf-8 locales (such as the default on windows).

noted on: 
- https://github.com/conda-forge/staged-recipes/pull/20888
  - [logs](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=595705&view=logs&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=2fb5b0a7-737c-5f5c-8f3f-f6db6174bacf&l=1112)

As a `noarch` package, this won't be a long-term issue, but for the initial build we like to make sure everything works on the "big three" advertised platforms.