### PR TITLE
Replace assignment expressions when packaging

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -30,10 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Replace assignment expressions (walrus operators)
-        run: |
-          pip install -e "git+https://github.com/pybpc/walrus.git#egg=bpc-walrus"
-          walrus jsf
       - name: Bootstrap Pants
         run: |
           ./pants --version

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Replace assignment expressions (walrus operators)
+        run: |
+          pip install -e "git+https://github.com/pybpc/walrus.git#egg=bpc-walrus"
+          walrus jsf
       - name: Bootstrap Pants
         run: |
           ./pants --version

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -21,6 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+      - name: Replace assignment expressions (walrus operators)
+        run: |
+          pip install -e "git+https://github.com/pybpc/walrus.git#egg=bpc-walrus"
+          walrus jsf
       - name: Bootstrap Pants
         run: |
           ./pants --version


### PR DESCRIPTION
jsf claims to support Python 3.7, however it uses assignment expressions (walrus operators) in one place which were introduced with Python 3.8.

This PR adds one step to the packaging workflow that replaces walrus operators using [walrus](https://github.com/pybpc/walrus).

This way, Python 3.7 support can be kept while allowing the use of walrus operators.