### PR TITLE
Add support for Pydantic 2.x

### DIFF
--- a/jsf/BUILD
+++ b/jsf/BUILD
@@ -44,7 +44,7 @@ python_distribution(
             "Data contract",
         ],
         zip_safe=True,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
         extras_require={"cli": ["typer>=0.7.0"]}
     ),
 )

--- a/jsf/cli.py
+++ b/jsf/cli.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import typer
+import typer  # pants: no-infer-dep
 
 from jsf.parser import JSF
 

--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from faker import Faker
 from jsonschema import validate
-from pydantic import conlist
 from smart_open import open as s_open
 
 from jsf.schema_types import (
@@ -37,7 +36,7 @@ class JSF:
             "faker": faker,
             "random": random,
             "datetime": datetime,
-            "__internal__": {"List": List, "Union": Union, "conlist": conlist},
+            "__internal__": {"List": List, "Union": Union, "Tuple": Tuple},
         },
         initial_state: Dict[str, Any] = {},
     ):

--- a/jsf/requirements.txt
+++ b/jsf/requirements.txt
@@ -1,6 +1,6 @@
 faker>=15.3.4
 jsonschema>=4.17.3
-pydantic>=1.10.4,<2.0.0
+pydantic >= 2.0.0
 rstr>=3.2.0
 smart-open[http]>=6.3.0
 

--- a/jsf/schema_types/_tuple.py
+++ b/jsf/schema_types/_tuple.py
@@ -27,7 +27,7 @@ class JSFTuple(BaseSchema):
 
     def model(self, context: Dict[str, Any]):
         _type = eval(
-            f"conlist(Union[{','.join([item.model(context)[0].__name__ for item in self.items])}], min_length={len(self.items)}, max_length={len(self.items)})",
+            f"Tuple[{','.join([item.model(context)[0].__name__ for item in self.items])}]",
             context["__internal__"],
         )
         return self.to_pydantic(context, _type)

--- a/jsf/schema_types/_tuple.py
+++ b/jsf/schema_types/_tuple.py
@@ -27,7 +27,7 @@ class JSFTuple(BaseSchema):
 
     def model(self, context: Dict[str, Any]):
         _type = eval(
-            f"conlist(Union[{','.join([item.model(context)[0].__name__ for item in self.items])}], min_items={len(self.items)}, max_items={len(self.items)})",
+            f"conlist(Union[{','.join([item.model(context)[0].__name__ for item in self.items])}], min_length={len(self.items)}, max_length={len(self.items)})",
             context["__internal__"],
         )
         return self.to_pydantic(context, _type)

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -23,7 +23,7 @@ class BaseSchema(BaseModel):
     # The examples keyword is a place to provide an array of examples that validate against the schema. This isn’t used for validation, but may help with explaining the effect and purpose of the schema to a reader. Each entry should validate against the schema in which is resides, but that isn’t strictly required. There is no need to duplicate the default value in the examples array, since default will be treated as another example.
     examples: Optional[List[Any]] = None
     # The $schema keyword is used to declare that a JSON fragment is actually a piece of JSON Schema. It also declares which version of the JSON Schema standard that the schema was written against.
-    _schema: Optional[str] = Field(None, alias="$schema")
+    schema_: Optional[str] = Field(None, alias="$schema")
     # The $comment keyword is strictly intended for adding comments to the JSON schema source. Its value must always be a string. Unlike the annotations title, description and examples, JSON schema implementations aren’t allowed to attach any meaning or behavior to it whatsoever, and may even strip them at any time. Therefore, they are useful for leaving notes to future editors of a JSON schema, (which is quite likely your future self), but should not be used to communicate to users of the schema.
     comments: Optional[str] = Field(None, alias="$comments")
 

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -33,6 +33,4 @@ class JSFEnum(BaseSchema):
         context["__internal__"][_type.__name__] = _type
         return self.to_pydantic(context, _type)
 
-    # TODO[pydantic]: The following keys were removed: `smart_union`.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
     model_config = ConfigDict()

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -35,4 +35,4 @@ class JSFEnum(BaseSchema):
 
     # TODO[pydantic]: The following keys were removed: `smart_union`.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    model_config = ConfigDict(smart_union=True)
+    model_config = ConfigDict()

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -3,6 +3,8 @@ import random
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import ConfigDict
+
 from jsf.schema_types.base import BaseSchema, ProviderNotSetException
 
 logger = logging.getLogger()
@@ -31,5 +33,6 @@ class JSFEnum(BaseSchema):
         context["__internal__"][_type.__name__] = _type
         return self.to_pydantic(context, _type)
 
-    class Config:
-        smart_union = True
+    # TODO[pydantic]: The following keys were removed: `smart_union`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(smart_union=True)

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -59,4 +59,4 @@ class Object(BaseSchema):
         return self.to_pydantic(context, _type)
 
 
-Object.update_forward_refs()
+Object.model_rebuild()

--- a/jsf/schema_types/string.py
+++ b/jsf/schema_types/string.py
@@ -51,9 +51,8 @@ def temporal_duration(
     if minutes != 0:
         duration = f"{duration}{minutes}M"
     if seconds + milliseconds + microseconds + nanoseconds != 0:
-        if remainder := "".join(
-            str(part) for part in [milliseconds, microseconds, nanoseconds] if part
-        ):
+        remainder = "".join(str(part) for part in [milliseconds, microseconds, nanoseconds] if part)
+        if remainder:
             seconds = f"{seconds}.{remainder}"
         duration = f"{duration}{seconds}S"
 
@@ -124,7 +123,7 @@ class String(BaseSchema):
     format: Optional[str] = None
     # enum: Optional[List[Union[str, int, float]]] = None  # NOTE: Not used - enums go to enum class
     contentMediaType: Optional[str] = None
-    contentEncoding: Optional[content_encoding.ContentEncoding]
+    contentEncoding: Optional[content_encoding.ContentEncoding] = None
     # contentSchema # Doesnt help with generation
 
     def generate(self, context: Dict[str, Any]) -> Optional[str]:

--- a/jsf/schema_types/string_utils/content_type/image__jpeg.py
+++ b/jsf/schema_types/string_utils/content_type/image__jpeg.py
@@ -1,6 +1,6 @@
 import random
 
-import requests
+import requests  # pants: no-infer-dep
 
 from jsf.schema_types.string_utils.content_encoding import bytes_str_repr
 

--- a/jsf/schema_types/string_utils/content_type/image__webp.py
+++ b/jsf/schema_types/string_utils/content_type/image__webp.py
@@ -1,6 +1,6 @@
 import random
 
-import requests
+import requests  # pants: no-infer-dep
 
 from jsf.schema_types.string_utils.content_encoding import bytes_str_repr
 

--- a/jsf/tests/BUILD
+++ b/jsf/tests/BUILD
@@ -10,5 +10,5 @@ files(
 python_tests(
     name="pytest",
     dependencies=[":tests"],
-    interpreter_constraints=parametrize(py3=[">=3.7,<4"]),
+    interpreter_constraints=parametrize(py3=[">=3.8,<4"]),
 )

--- a/jsf/tests/test_cli.py
+++ b/jsf/tests/test_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from jsf.cli import app
 from jsonschema import validate
-from typer.testing import CliRunner
+from typer.testing import CliRunner  # pants: no-infer-dep
 
 runner = CliRunner()
 

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-import jwt
+import jwt  # pants: no-infer-dep
 from jsf.parser import JSF
 
 

--- a/jsf/tests/test_model_gen.py
+++ b/jsf/tests/test_model_gen.py
@@ -20,7 +20,7 @@ expected = [
     ("custom", Object),
     ("string-enum", Enum),
     ("string", str),
-    ("tuple", tuple),
+    # ("tuple", tuple), # Fixme: I am not sure why this test fails
 ]
 if int(platform.python_version_tuple()[1]) < 9:
     expected.append(("array", List))
@@ -44,5 +44,6 @@ def test_gen_model(TestData, filestem, expected_type_anno):
     with open(TestData / f"{filestem}.json", "r") as file:
         schema = json.load(file)
     p = JSF(schema)
+    print(schema)
     Model = p.pydantic()
     assert type(expected_type_anno) == type(Model)

--- a/jsf/tests/test_model_gen.py
+++ b/jsf/tests/test_model_gen.py
@@ -1,7 +1,7 @@
 import json
 import platform
 from enum import Enum
-from typing import List
+from typing import List, _GenericAlias
 
 import pytest  # pants: no-infer-dep
 from jsf.parser import JSF
@@ -20,13 +20,11 @@ expected = [
     ("custom", Object),
     ("string-enum", Enum),
     ("string", str),
-    # ("tuple", tuple), # Fixme: I am not sure why this test fails
 ]
 if int(platform.python_version_tuple()[1]) < 9:
     expected.append(("array", List))
 
 else:
-    from typing import _GenericAlias
 
     def test_gen_model_list(TestData):
         with open(TestData / "array.json", "r") as file:
@@ -34,6 +32,14 @@ else:
         p = JSF(schema)
         Model = p.pydantic()
         assert _GenericAlias == type(Model)
+
+
+def test_gen_model_tuple(TestData):
+    with open(TestData / "tuple.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+    Model = p.pydantic()
+    assert _GenericAlias == type(Model)
 
 
 @pytest.mark.parametrize(
@@ -44,6 +50,5 @@ def test_gen_model(TestData, filestem, expected_type_anno):
     with open(TestData / f"{filestem}.json", "r") as file:
         schema = json.load(file)
     p = JSF(schema)
-    print(schema)
     Model = p.pydantic()
     assert type(expected_type_anno) == type(Model)

--- a/pants.toml
+++ b/pants.toml
@@ -7,11 +7,11 @@ backend_packages = [
 	"pants.backend.python.lint.docformatter",
 	"pants.backend.python.lint.isort",
 	"pants.backend.python.lint.black",
-	"pants.backend.experimental.python.lint.pyupgrade"
+	"pants.backend.experimental.python.lint.pyupgrade",
 ]
 
 [python]
-interpreter_constraints = ["CPython>=3.7,<4"]
+interpreter_constraints = ["CPython>=3.8,<4"]
 
 [flake8]
 config = ".flake8"
@@ -20,11 +20,7 @@ config = ".flake8"
 use_coverage = true
 
 [pytest]
-extra_requirements = [
-	"typer>=0.7.0",
-	"pyjwt",
-	"pytest-cov"
-]
+extra_requirements = ["typer>=0.7.0", "pyjwt", "pytest-cov"]
 lockfile = "<none>"
 
 [coverage-py]

--- a/pants.toml
+++ b/pants.toml
@@ -20,7 +20,11 @@ config = ".flake8"
 use_coverage = true
 
 [pytest]
-extra_requirements = ["typer>=0.7.0", "pyjwt", "pytest-cov"]
+extra_requirements = [
+	"typer>=0.7.0", 
+	"pyjwt", 
+	"pytest-cov",
+]
 lockfile = "<none>"
 
 [coverage-py]


### PR DESCRIPTION
BREAKING CHANGE: breaks consumers that are on pydanticV1 

Further, moved to >= python3.8, since 3.7 should not have worked in the first place.