### PR TITLE
fix: use valid pydantic field name

### DIFF
--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -23,7 +23,7 @@ class BaseSchema(BaseModel):
     # The examples keyword is a place to provide an array of examples that validate against the schema. This isn’t used for validation, but may help with explaining the effect and purpose of the schema to a reader. Each entry should validate against the schema in which is resides, but that isn’t strictly required. There is no need to duplicate the default value in the examples array, since default will be treated as another example.
     examples: Optional[List[Any]] = None
     # The $schema keyword is used to declare that a JSON fragment is actually a piece of JSON Schema. It also declares which version of the JSON Schema standard that the schema was written against.
-    _schema: Optional[str] = Field(None, alias="$schema")
+    json_schema: Optional[str] = Field(None, alias="$schema")
     # The $comment keyword is strictly intended for adding comments to the JSON schema source. Its value must always be a string. Unlike the annotations title, description and examples, JSON schema implementations aren’t allowed to attach any meaning or behavior to it whatsoever, and may even strip them at any time. Therefore, they are useful for leaving notes to future editors of a JSON schema, (which is quite likely your future self), but should not be used to communicate to users of the schema.
     comments: Optional[str] = Field(None, alias="$comments")
 


### PR DESCRIPTION
The following change in pydantic breaks jsf: https://github.com/pydantic/pydantic/pull/6797
It is part of pydantic 2.1
Partial traceback:
```
File jsf/schema_types/base.py:15
     11 class ProviderNotSetException(Exception):
     12     ...
---> 15 class BaseSchema(BaseModel):
     17     type: Optional[Union[str, List[str]]] = None

NameError: Fields must not use names with leading underscores; e.g., use 'schema' instead of '_schema'.
```

Renamed invalid '_schema' field name to 'json_schema'.
