### PR TITLE
feat: force to generate for non-required fields

### DIFF
--- a/jsf/README.md
+++ b/jsf/README.md
@@ -85,7 +85,7 @@ fake_json = faker.generate()
 ```
 
 <details markdown="1">
-<summary>Or run stright from the <code>commandline</code>...</summary>
+<summary>Or run straight from the <code>commandline</code>...</summary>
 
 #### Native install
 

--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -5,8 +5,8 @@ from collections import ChainMap
 from copy import deepcopy
 from datetime import datetime
 from itertools import count
-from typing import Any, Dict, List, Optional, Tuple, Union
 from types import MappingProxyType
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from faker import Faker
 from jsonschema import validate
@@ -33,14 +33,16 @@ class JSF:
     def __init__(
         self,
         schema: Dict[str, Any],
-        context: Dict[str, Any] = MappingProxyType({
-            "faker": faker,
-            "random": random,
-            "datetime": datetime,
-            "__internal__": {"List": List, "Union": Union, "Tuple": Tuple},
-        }),
+        context: Dict[str, Any] = MappingProxyType(
+            {
+                "faker": faker,
+                "random": random,
+                "datetime": datetime,
+                "__internal__": {"List": List, "Union": Union, "Tuple": Tuple},
+            }
+        ),
         initial_state: Dict[str, Any] = MappingProxyType({}),
-        allow_none_optionals: bool = True
+        allow_none_optionals: bool = True,
     ):
         self.root_schema = schema
         self.definitions = {}
@@ -58,11 +60,27 @@ class JSF:
     def __parse_primitive(self, name: str, path: str, schema: Dict[str, Any]) -> PrimitiveTypes:
         item_type, is_nullable = self.__is_field_nullable(schema)
         cls = Primitives.get(item_type)
-        return cls.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
+        return cls.from_dict(
+            {
+                "name": name,
+                "path": path,
+                "is_nullable": is_nullable,
+                "allow_none_optionals": self.allow_none_optionals,
+                **schema,
+            }
+        )
 
     def __parse_object(self, name: str, path: str, schema: Dict[str, Any]) -> Object:
         _, is_nullable = self.__is_field_nullable(schema)
-        model = Object.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
+        model = Object.from_dict(
+            {
+                "name": name,
+                "path": path,
+                "is_nullable": is_nullable,
+                "allow_none_optionals": self.allow_none_optionals,
+                **schema,
+            }
+        )
         props = []
         for _name, definition in schema.get("properties", {}).items():
             props.append(self.__parse_definition(_name, path=f"{path}/{_name}", schema=definition))
@@ -78,13 +96,29 @@ class JSF:
 
     def __parse_array(self, name: str, path: str, schema: Dict[str, Any]) -> Array:
         _, is_nullable = self.__is_field_nullable(schema)
-        arr = Array.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
+        arr = Array.from_dict(
+            {
+                "name": name,
+                "path": path,
+                "is_nullable": is_nullable,
+                "allow_none_optionals": self.allow_none_optionals,
+                **schema,
+            }
+        )
         arr.items = self.__parse_definition(name, name, schema["items"])
         return arr
 
     def __parse_tuple(self, name: str, path: str, schema: Dict[str, Any]) -> JSFTuple:
         _, is_nullable = self.__is_field_nullable(schema)
-        arr = JSFTuple.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
+        arr = JSFTuple.from_dict(
+            {
+                "name": name,
+                "path": path,
+                "is_nullable": is_nullable,
+                "allow_none_optionals": self.allow_none_optionals,
+                **schema,
+            }
+        )
         arr.items = []
         for i, item in enumerate(schema["items"]):
             arr.items.append(self.__parse_definition(name, path=f"{name}[{i}]", schema=item))
@@ -148,7 +182,13 @@ class JSF:
                 isinstance(item, (int, float, str, type(None))) for item in enum_list
             ), "Enum Type is not null, int, float or string"
             return JSFEnum.from_dict(
-                {"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema}
+                {
+                    "name": name,
+                    "path": path,
+                    "is_nullable": is_nullable,
+                    "allow_none_optionals": self.allow_none_optionals,
+                    **schema,
+                }
             )
         elif "type" in schema:
             if item_type == "object" and "properties" in schema:

--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime
 from itertools import count
 from typing import Any, Dict, List, Optional, Tuple, Union
+from types import MappingProxyType
 
 from faker import Faker
 from jsonschema import validate
@@ -32,13 +33,14 @@ class JSF:
     def __init__(
         self,
         schema: Dict[str, Any],
-        context: Dict[str, Any] = {
+        context: Dict[str, Any] = MappingProxyType({
             "faker": faker,
             "random": random,
             "datetime": datetime,
             "__internal__": {"List": List, "Union": Union, "Tuple": Tuple},
-        },
-        initial_state: Dict[str, Any] = {},
+        }),
+        initial_state: Dict[str, Any] = MappingProxyType({}),
+        allow_none_optionals: bool = True
     ):
         self.root_schema = schema
         self.definitions = {}
@@ -48,6 +50,7 @@ class JSF:
             **initial_state,
         }
         self.base_context = context
+        self.allow_none_optionals = allow_none_optionals
 
         self.root = None
         self._parse(schema)
@@ -55,11 +58,11 @@ class JSF:
     def __parse_primitive(self, name: str, path: str, schema: Dict[str, Any]) -> PrimitiveTypes:
         item_type, is_nullable = self.__is_field_nullable(schema)
         cls = Primitives.get(item_type)
-        return cls.from_dict({"name": name, "path": path, "is_nullable": is_nullable, **schema})
+        return cls.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
 
     def __parse_object(self, name: str, path: str, schema: Dict[str, Any]) -> Object:
         _, is_nullable = self.__is_field_nullable(schema)
-        model = Object.from_dict({"name": name, "path": path, "is_nullable": is_nullable, **schema})
+        model = Object.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
         props = []
         for _name, definition in schema.get("properties", {}).items():
             props.append(self.__parse_definition(_name, path=f"{path}/{_name}", schema=definition))
@@ -75,13 +78,13 @@ class JSF:
 
     def __parse_array(self, name: str, path: str, schema: Dict[str, Any]) -> Array:
         _, is_nullable = self.__is_field_nullable(schema)
-        arr = Array.from_dict({"name": name, "path": path, "is_nullable": is_nullable, **schema})
+        arr = Array.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
         arr.items = self.__parse_definition(name, name, schema["items"])
         return arr
 
     def __parse_tuple(self, name: str, path: str, schema: Dict[str, Any]) -> JSFTuple:
         _, is_nullable = self.__is_field_nullable(schema)
-        arr = JSFTuple.from_dict({"name": name, "path": path, "is_nullable": is_nullable, **schema})
+        arr = JSFTuple.from_dict({"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema})
         arr.items = []
         for i, item in enumerate(schema["items"]):
             arr.items.append(self.__parse_definition(name, path=f"{name}[{i}]", schema=item))
@@ -145,7 +148,7 @@ class JSF:
                 isinstance(item, (int, float, str, type(None))) for item in enum_list
             ), "Enum Type is not null, int, float or string"
             return JSFEnum.from_dict(
-                {"name": name, "path": path, "is_nullable": is_nullable, **schema}
+                {"name": name, "path": path, "is_nullable": is_nullable, "allow_none_optionals": self.allow_none_optionals, **schema}
             )
         elif "type" in schema:
             if item_type == "object" and "properties" in schema:

--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -42,7 +42,7 @@ class JSF:
             }
         ),
         initial_state: Dict[str, Any] = MappingProxyType({}),
-        allow_none_optionals: float = 0.0,
+        allow_none_optionals: float = 0.5,
     ):
         self.root_schema = schema
         self.definitions = {}

--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -42,7 +42,7 @@ class JSF:
             }
         ),
         initial_state: Dict[str, Any] = MappingProxyType({}),
-        allow_none_optionals: bool = True,
+        allow_none_optionals: float = 0.0,
     ):
         self.root_schema = schema
         self.definitions = {}

--- a/jsf/schema_types/_tuple.py
+++ b/jsf/schema_types/_tuple.py
@@ -15,7 +15,8 @@ class JSFTuple(BaseSchema):
     uniqueItems: Optional[bool] = False
     fixed: Optional[Union[int, str]] = Field(None, alias="$fixed")
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return JSFTuple(**d)
 
     def generate(self, context: Dict[str, Any]) -> Optional[List[Tuple]]:

--- a/jsf/schema_types/allof.py
+++ b/jsf/schema_types/allof.py
@@ -6,7 +6,8 @@ from jsf.schema_types.base import BaseSchema, ProviderNotSetException
 class AllOf(BaseSchema):
     combined_schema: BaseSchema = None
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return AllOf(**d)
 
     def generate(self, context: Dict[str, Any]) -> Optional[Any]:

--- a/jsf/schema_types/anyof.py
+++ b/jsf/schema_types/anyof.py
@@ -7,7 +7,8 @@ from jsf.schema_types.base import BaseSchema, ProviderNotSetException
 class AnyOf(BaseSchema):
     schemas: List[BaseSchema] = None
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return AnyOf(**d)
 
     def generate(self, context: Dict[str, Any]) -> Optional[Any]:

--- a/jsf/schema_types/array.py
+++ b/jsf/schema_types/array.py
@@ -14,7 +14,8 @@ class Array(BaseSchema):
     uniqueItems: Optional[bool] = False
     fixed: Optional[Union[int, str]] = Field(None, alias="$fixed")
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return Array(**d)
 
     def generate(self, context: Dict[str, Any]) -> Optional[List[Any]]:

--- a/jsf/schema_types/array.py
+++ b/jsf/schema_types/array.py
@@ -29,7 +29,7 @@ class Array(BaseSchema):
 
             output = [
                 self.items.generate(context)
-                for _ in range(random.randint(self.minItems, self.maxItems))
+                for _ in range(random.randint(int(self.minItems), int(self.maxItems)))
             ]
             if self.uniqueItems and self.items.type == "object":
                 output = [dict(s) for s in {frozenset(d.items()) for d in output}]

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -33,7 +33,7 @@ class BaseSchema(BaseModel):
     provider: Optional[str] = Field(None, alias="$provider")
     set_state: Optional[Dict[str, str]] = Field(None, alias="$state")
     is_nullable: bool = False
-    allow_none_optionals: bool = True
+    allow_none_optionals: float = 1.0
 
     @classmethod
     def from_dict(cls, d: Dict):
@@ -43,7 +43,7 @@ class BaseSchema(BaseModel):
         if self.set_state is not None:
             context["state"][self.path] = {k: eval(v, context)() for k, v in self.set_state.items()}
 
-        if self.is_nullable and self.allow_none_optionals and random.uniform(0, 1) < 0.9:
+        if self.is_nullable and random.uniform(0, 1) < self.allow_none_optionals:
             return None
         if self.provider is not None:
             return eval(self.provider, context)()

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -33,7 +33,7 @@ class BaseSchema(BaseModel):
     provider: Optional[str] = Field(None, alias="$provider")
     set_state: Optional[Dict[str, str]] = Field(None, alias="$state")
     is_nullable: bool = False
-    allow_none_optionals: float = 1.0
+    allow_none_optionals: float = 0.5
 
     @classmethod
     def from_dict(cls, d: Dict):

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -33,7 +33,7 @@ class BaseSchema(BaseModel):
     provider: Optional[str] = Field(None, alias="$provider")
     set_state: Optional[Dict[str, str]] = Field(None, alias="$state")
     is_nullable: bool = False
-    allow_none_optionals: float = 0.5
+    allow_none_optionals: float = Field(0.5, ge=0.0, le=1.0)
 
     @classmethod
     def from_dict(cls, d: Dict):

--- a/jsf/schema_types/base.py
+++ b/jsf/schema_types/base.py
@@ -33,15 +33,17 @@ class BaseSchema(BaseModel):
     provider: Optional[str] = Field(None, alias="$provider")
     set_state: Optional[Dict[str, str]] = Field(None, alias="$state")
     is_nullable: bool = False
+    allow_none_optionals: bool = True
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         raise NotImplementedError  # pragma: no cover
 
     def generate(self, context: Dict[str, Any]) -> Any:
         if self.set_state is not None:
             context["state"][self.path] = {k: eval(v, context)() for k, v in self.set_state.items()}
 
-        if self.is_nullable and random.uniform(0, 1) < 0.9:
+        if self.is_nullable and self.allow_none_optionals and random.uniform(0, 1) < 0.9:
             return None
         if self.provider is not None:
             return eval(self.provider, context)()
@@ -62,4 +64,4 @@ class BaseSchema(BaseModel):
                 Optional[_type],
                 Field(..., description=self.description, example=example),
             )
-        return (_type, Field(..., description=self.description, example=example))
+        return _type, Field(..., description=self.description, example=example)

--- a/jsf/schema_types/boolean.py
+++ b/jsf/schema_types/boolean.py
@@ -14,5 +14,6 @@ class Boolean(BaseSchema):
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, bool)
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return Boolean(**d)

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -20,7 +20,8 @@ class JSFEnum(BaseSchema):
         except ProviderNotSetException:
             return random.choice(self.enum)
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return JSFEnum(**d)
 
     def model(self, context: Dict[str, Any]):

--- a/jsf/schema_types/null.py
+++ b/jsf/schema_types/null.py
@@ -13,5 +13,6 @@ class Null(BaseSchema):
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, type(None))
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return Null(**d)

--- a/jsf/schema_types/number.py
+++ b/jsf/schema_types/number.py
@@ -40,7 +40,8 @@ class Number(BaseSchema):
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, float)
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return Number(**d)
 
 
@@ -52,5 +53,6 @@ class Integer(Number):
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, int)
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return Integer(**d)

--- a/jsf/schema_types/number.py
+++ b/jsf/schema_types/number.py
@@ -34,7 +34,7 @@ class Number(BaseSchema):
                 _max = self.maximum
 
             return float(
-                step * random.uniform(math.ceil(float(_min) / step), math.floor(float(_max) / step))
+                step * random.randint(math.ceil(float(_min) / step), math.floor(float(_max) / step))
             )
 
     def model(self, context: Dict[str, Any]):

--- a/jsf/schema_types/number.py
+++ b/jsf/schema_types/number.py
@@ -34,7 +34,7 @@ class Number(BaseSchema):
                 _max = self.maximum
 
             return float(
-                step * random.randint(math.ceil(float(_min) / step), math.floor(float(_max) / step))
+                step * random.uniform(math.ceil(float(_min) / step), math.floor(float(_max) / step))
             )
 
     def model(self, context: Dict[str, Any]):

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -28,11 +28,12 @@ class Object(BaseSchema):
     dependencies: Optional[Union[PropertyDependency, SchemaDependency]] = None
     patternProperties: Optional[Dict[str, BaseSchema]] = None
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: dict):
         return Object(**d)
 
     def should_keep(self, property_name: str) -> bool:
-        if isinstance(self.required, list) and property_name in self.required:
+        if not self.allow_none_optionals or (isinstance(self.required, list) and property_name in self.required):
             return True
         return random.uniform(0, 1) < 0.5
 

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -33,11 +33,9 @@ class Object(BaseSchema):
         return Object(**d)
 
     def should_keep(self, property_name: str) -> bool:
-        if random.uniform(0, 1) > self.allow_none_optionals or (
-            isinstance(self.required, list) and property_name in self.required
-        ):
+        if isinstance(self.required, list) and property_name in self.required:
             return True
-        return random.uniform(0, 1) < 0.5
+        return random.uniform(0, 1) > self.allow_none_optionals
 
     def generate(self, context: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         try:

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -33,7 +33,9 @@ class Object(BaseSchema):
         return Object(**d)
 
     def should_keep(self, property_name: str) -> bool:
-        if not self.allow_none_optionals or (isinstance(self.required, list) and property_name in self.required):
+        if not self.allow_none_optionals or (
+            isinstance(self.required, list) and property_name in self.required
+        ):
             return True
         return random.uniform(0, 1) < 0.5
 

--- a/jsf/schema_types/object.py
+++ b/jsf/schema_types/object.py
@@ -33,7 +33,7 @@ class Object(BaseSchema):
         return Object(**d)
 
     def should_keep(self, property_name: str) -> bool:
-        if not self.allow_none_optionals or (
+        if random.uniform(0, 1) > self.allow_none_optionals or (
             isinstance(self.required, list) and property_name in self.required
         ):
             return True

--- a/jsf/schema_types/oneof.py
+++ b/jsf/schema_types/oneof.py
@@ -7,7 +7,8 @@ from jsf.schema_types.base import BaseSchema, ProviderNotSetException
 class OneOf(BaseSchema):
     schemas: List[BaseSchema] = None
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return OneOf(**d)
 
     def generate(self, context: Dict[str, Any]) -> Optional[List[Any]]:

--- a/jsf/schema_types/string.py
+++ b/jsf/schema_types/string.py
@@ -68,7 +68,7 @@ def temporal_duration(
 
 
 def mostly_zero_randint(_min: int, _max: int) -> int:
-    return 0 if random.random() > 0.8 else random.randint(_min, _max)
+    return 0 if random.random() > 0.8 else random.randint(int(_min), int(_max))
 
 
 def fake_duration():

--- a/jsf/schema_types/string.py
+++ b/jsf/schema_types/string.py
@@ -67,8 +67,8 @@ def temporal_duration(
     return duration
 
 
-def mostly_zero_randint(min, max):
-    return 0 if random.random() > 0.8 else random.randint(min, max)
+def mostly_zero_randint(_min: int, _max: int):
+    return 0 if random.random() > 0.8 else random.randint(_min, _max)
 
 
 def fake_duration():
@@ -117,8 +117,8 @@ format_map: Dict[str, Callable] = {
 
 
 class String(BaseSchema):
-    minLength: Optional[float] = 0
-    maxLength: Optional[float] = 50
+    minLength: Optional[int] = 0
+    maxLength: Optional[int] = 50
     pattern: Optional[str] = None
     format: Optional[str] = None
     # enum: Optional[List[Union[str, int, float]]] = None  # NOTE: Not used - enums go to enum class
@@ -151,5 +151,6 @@ class String(BaseSchema):
     def model(self, context: Dict[str, Any]):
         return self.to_pydantic(context, str)
 
-    def from_dict(d):
+    @classmethod
+    def from_dict(cls, d: Dict):
         return String(**d)

--- a/jsf/schema_types/string.py
+++ b/jsf/schema_types/string.py
@@ -67,7 +67,7 @@ def temporal_duration(
     return duration
 
 
-def mostly_zero_randint(_min: int, _max: int):
+def mostly_zero_randint(_min: int, _max: int) -> int:
     return 0 if random.random() > 0.8 else random.randint(_min, _max)
 
 

--- a/jsf/schema_types/string_utils/content_encoding.py
+++ b/jsf/schema_types/string_utils/content_encoding.py
@@ -1,7 +1,6 @@
 import base64
 import quopri
 from enum import Enum
-from typing import Optional
 
 
 class ContentEncoding(str, Enum):
@@ -57,5 +56,5 @@ Encoder = {
 }
 
 
-def encode(string: str, encoding: Optional[ContentEncoding]) -> str:
+def encode(string: str, encoding: ContentEncoding) -> str:
     return Encoder.get(encoding, lambda s: s)(string)

--- a/jsf/schema_types/string_utils/content_type/text__plain.py
+++ b/jsf/schema_types/string_utils/content_type/text__plain.py
@@ -1,8 +1,25 @@
 import random
-import string
+
+LOREM = """Lorem ipsum dolor sit amet consectetur adipisicing elit.
+Hic molestias, esse veniam placeat officiis nobis architecto modi
+possimus reiciendis accusantium exercitationem quas illum libero odit magnam,
+reprehenderit ipsum, repellendus culpa! Nullam vehicula ipsum a arcu cursus vitae congue.
+Enim nec dui nunc mattis enim ut tellus.""".split()
 
 
 def random_fixed_length_sentence(_min: int = 0, _max: int = 50) -> str:
     if _min > _max:
         raise ValueError("'_max' should be greater than '_min'")  # pragma: no cover
-    return "".join(random.choice(string.ascii_lowercase) for _ in range(random.randint(int(_min), int(_max))))
+    output = ""
+    while True:
+        remaining = _max - len(output)
+        valid_words = list(filter(lambda s: len(s) <= remaining, LOREM))
+        if len(valid_words) == 0:
+            break
+        if len(output) >= _min and random.uniform(0, 1) > 0.5:
+            break
+        output += random.choice(valid_words) + " "
+    output = output.strip()
+    if len(output) < _min:
+        output = output + "."
+    return output

--- a/jsf/schema_types/string_utils/content_type/text__plain.py
+++ b/jsf/schema_types/string_utils/content_type/text__plain.py
@@ -16,7 +16,7 @@ def random_fixed_length_sentence(_min: int = 0, _max: int = 50) -> str:
         valid_words = list(filter(lambda s: len(s) <= remaining, LOREM))
         if len(valid_words) == 0:
             break
-        if len(output) >= _min and random.uniform(0, 1) > 0.5:
+        if len(output) >= _min and random.uniform(0, 1) > 0.9:
             break
         output += random.choice(valid_words) + " "
     output = output.strip()

--- a/jsf/schema_types/string_utils/content_type/text__plain.py
+++ b/jsf/schema_types/string_utils/content_type/text__plain.py
@@ -1,9 +1,8 @@
 import random
 import string
-from typing import Optional
 
 
-def random_fixed_length_sentence(_min: Optional[int] = 0, _max: Optional[int] = 50) -> str:
+def random_fixed_length_sentence(_min: int = 0, _max: int = 50) -> str:
     if _min > _max:
         raise ValueError("'_max' should be greater than '_min'")  # pragma: no cover
-    return ''.join(random.choice(string.ascii_lowercase) for _ in range(random.randint(_min, _max)))
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(random.randint(_min, _max)))

--- a/jsf/schema_types/string_utils/content_type/text__plain.py
+++ b/jsf/schema_types/string_utils/content_type/text__plain.py
@@ -5,4 +5,4 @@ import string
 def random_fixed_length_sentence(_min: int = 0, _max: int = 50) -> str:
     if _min > _max:
         raise ValueError("'_max' should be greater than '_min'")  # pragma: no cover
-    return "".join(random.choice(string.ascii_lowercase) for _ in range(random.randint(_min, _max)))
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(random.randint(int(_min), int(_max))))

--- a/jsf/schema_types/string_utils/content_type/text__plain.py
+++ b/jsf/schema_types/string_utils/content_type/text__plain.py
@@ -1,19 +1,9 @@
 import random
-
-LOREM = """Lorem ipsum dolor sit amet consectetur adipisicing elit.
-Hic molestias, esse veniam placeat officiis nobis architecto modi
-possimus reiciendis accusantium exercitationem quas illum libero odit magnam,
-reprehenderit ipsum, repellendus culpa!""".split()
+import string
+from typing import Optional
 
 
-def random_fixed_length_sentence(_min: int = 0, _max: int = 50) -> str:
-    output = ""
-    while len(output) < _max:
-        remaining = _max - len(output)
-        valid_words = list(filter(lambda s: len(s) < remaining, LOREM))
-        if len(valid_words) == 0:
-            break
-        output += random.choice(valid_words) + " "
-        if len(output) > _min and random.uniform(0, 1) > 0.9:
-            break
-    return output.strip()
+def random_fixed_length_sentence(_min: Optional[int] = 0, _max: Optional[int] = 50) -> str:
+    if _min > _max:
+        raise ValueError("'_max' should be greater than '_min'")  # pragma: no cover
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(random.randint(_min, _max)))

--- a/jsf/tests/data/object-with-optionals.json
+++ b/jsf/tests/data/object-with-optionals.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "required": ["name"],
+    "properties": {
+        "name": { "type": "string" },
+        "credit_card": { "type": "number" }
+    }
+}

--- a/jsf/tests/data/string-max-min-length.json
+++ b/jsf/tests/data/string-max-min-length.json
@@ -1,0 +1,5 @@
+{
+    "type": "string",
+    "maxLength": 2,
+    "minLength": 2
+}

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -440,7 +440,8 @@ def test_list_of_types(TestData):
 def test_non_required_are_not_none(TestData):
     with open(TestData / "object-with-optionals.json", "r") as file:
         schema = json.load(file)
-    fake_data = JSF(schema, allow_none_optionals=False).generate()
+    for _ in range(10):
+        fake_data = JSF(schema, allow_none_optionals=0.0).generate()
 
-    assert fake_data["name"] is not None
-    assert fake_data["credit_card"] is not None
+        assert fake_data["name"] is not None
+        assert fake_data["credit_card"] is not None

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -110,6 +110,15 @@ def test_fake_string(TestData):
     assert len(fake_data) - len(set(fake_data)) < 50
 
 
+def test_fake_string_max_min_length(TestData):
+    with open(TestData / "string-max-min-length.json", "r") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+    assert isinstance(p.generate(), str)
+    fake_data = [p.generate() for _ in range(10)]
+    assert all(len(fd) == 2 for fd in fake_data)
+
+
 def test_fake_string_content_encoding(TestData):
     with open(TestData / "string-content-encoding.json", "r") as file:
         schema = json.load(file)
@@ -426,3 +435,12 @@ def test_list_of_types(TestData):
     assert all(type(f["randTypeValue"]) in [bool, int, float, str] for f in fake_data), fake_data
     assert all(isinstance(f["int"], int) for f in fake_data), fake_data
     assert all(isinstance(f["null"], type(None)) for f in fake_data), fake_data
+
+
+def test_non_required_are_not_none(TestData):
+    with open(TestData / "object-with-optionals.json", "r") as file:
+        schema = json.load(file)
+    fake_data = JSF(schema, allow_none_optionals=False).generate()
+
+    assert fake_data["name"] is not None
+    assert fake_data["credit_card"] is not None


### PR DESCRIPTION
Changes:

- Allow to create `strings` of any length. If the generated string ends with a space, it will be changed to a dot (eg. 'at.' instead of 'at '. Just to avoid confusion.
- Allow to generate data even for non-required fields (similar to: [Polyfactory __allow_none_optionals__](https://polyfactory.litestar.dev/reference/factories/base.html#polyfactory.factories.base.BaseFactory.__allow_none_optionals__)). The value should be a float between `0.0` and `1.0`, indicating the probability of allowing getting a `None` value. `0.0` means "0% chances of getting a `None`", `1.0` means "100% chances of getting a `None`", `0.5` means "50% chances of getting a `None`", etc. The default is `0.5`.
- Minor improvements