### PR TITLE
Release 0.10.0 - Support forcing non required fields

### DIFF
--- a/jsf/BUILD
+++ b/jsf/BUILD
@@ -22,7 +22,7 @@ python_distribution(
     long_description_path="README.md",
     provides=python_artifact(
         name="jsf",
-        version="0.9.0",
+        version="0.10.0",
         author="ghandic",
         description="Creates fake JSON files from a JSON schema",
         url="https://github.com/ghandic/jsf",


### PR DESCRIPTION
- Allow to create strings of any length. If the generated string ends with a space, it will be changed to a dot (eg. 'at.' instead of 'at '. Just to avoid confusion.
- Allow to generate data even for non-required fields (similar to: [Polyfactory allow_none_optionals](https://polyfactory.litestar.dev/reference/factories/base.html#polyfactory.factories.base.BaseFactory.__allow_none_optionals__)). The value should be a float between 0.0 and 1.0, indicating the probability of allowing getting a None value. 0.0 means "0% chances of getting a None", 1.0 means "100% chances of getting a None", 0.5 means "50% chances of getting a None", etc. The default is 0.5.