### PR TITLE
fix: support empty schemas

### DIFF
--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -319,6 +319,8 @@ class JSF:
             return self.__parse_allOf(name, path, schema, root)
         elif "oneOf" in schema:
             return self.__parse_oneOf(name, path, schema, root)
+        elif not any(key in schema for key in ["not", "if", "then", "else"]):
+            return self.__parse_primitive(name, path, {**schema, "type": list(Primitives.keys())})
         else:
             raise ValueError(f"Cannot parse schema {repr(schema)}")  # pragma: no cover
 

--- a/jsf/tests/data/empty.json
+++ b/jsf/tests/data/empty.json
@@ -1,0 +1,3 @@
+{
+    "title": "Any valid JSON"
+}

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -498,3 +498,9 @@ def test_fake_complex_recursive(TestData):
         assert isinstance(d, str) or isinstance(d, dict)
         if isinstance(d, dict):
             assert "value" in d
+
+
+def test_fake_empty(TestData):
+    with open(TestData / "empty.json") as file:
+        schema = json.load(file)
+    [JSF(schema).generate() for _ in range(10)]  # Just validating no errors


### PR DESCRIPTION
- add support for empty json schemas, which accept any valid json according to the [specs](https://json-schema.org/understanding-json-schema/basics#hello-world!)